### PR TITLE
Memoization and other optimizations and fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
   - "pypy3.5"
+  - "pypy3"
 
 install:
   - pip install tox-travis

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Unlike the other decorator, this one uses `weakref`, so it doesn't interfere wit
 
 Methods are documented with reStructuredText inside docstrings. This looks a little like markdown, but it's different, so take care and look at other docstrings for examples.
 
-Documentation is automatically generated and ends up at [Read the Docs](https://hypothesis.readthedocs.io/en/latest/).
+Documentation is automatically generated and ends up at [Read the Docs](https://python-nnf.readthedocs.io/en/latest/).
 
 To build the documentation locally, run `make html` inside the `docs/` directory. This generates a manual in `docs/_build/html/`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 [`tox`](https://tox.readthedocs.io/en/latest/) is used to run the tests and linters. After installing it, run:
 
 ```
-tox -e py3
+tox
 ```
 
 This will install and run all the tooling.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,80 @@
 # Contributing to python-nnf
 
-More information coming soon.
+## Running the tests and linters
 
-## Notes for now
+[`tox`](https://tox.readthedocs.io/en/latest/) is used to run the tests and linters. After installing it, run:
 
-- `tox -e py3`
-- Set notation for Internal nodes (rather than lists)
-- Use of `@memoize`
-- Use of Typing / mypy
+```
+tox -e py3
+```
+
+This will install and run all the tooling.
+
+## Mypy
+
+[Mypy](https://mypy.readthedocs.io/en/stable/) is used for static typing. This is also managed by `tox`.
+
+You can look at the existing code for cues. If you can't figure it out, just leave it be and we'll look at it during code review.
+
+## Hypothesis
+
+[Hypothesis](https://hypothesis.readthedocs.io/en/latest/) is used for property-based testing: it generates random sentences for tests to use. See the existing tests for examples.
+
+It's ideal for a feature to have both tests that do use Hypothesis and tests that don't.
+
+## Memoization
+
+[Memoization](https://en.wikipedia.org/wiki/Memoization) is used in various places to avoid computing the same thing multiple times. A memoized function remembers past calls so it can return the same return value again in the future.
+
+A downside of memoization is that it increases memory usage.
+
+It's used in two patterns throughout the codebase:
+
+### Temporary internal memoization with `@memoize`
+
+This is used for functions that run on individual nodes of sentences, within a method. For example:
+
+```python
+    def height(self) -> int:
+        """The number of edges between here and the furthest leaf."""
+        @memoize
+        def height(node: NNF) -> int:
+            if isinstance(node, Internal) and node.children:
+                return 1 + max(height(child) for child in node.children)
+            return 0
+
+        return height(self)
+```
+
+Because the function is defined inside the method, it's garbage collected along with its cache when the method returns. This makes sure we don't keep all the individual node heights in memory indefinitely.
+
+### Memoizing sentence properties with `@weakref_memoize`
+
+This is used for commonly used methods that run on whole sentences. For example:
+
+```python
+    @weakref_memoize
+    def vars(self) -> t.FrozenSet[Name]:
+        """The names of all variables that appear in the sentence."""
+        return frozenset(node.name
+                         for node in self.walk()
+                         if isinstance(node, Var))
+```
+
+This lets us call `.vars()` often without worrying about performance.
+
+Unlike the other decorator, this one uses `weakref`, so it doesn't interfere with garbage collection. It's slightly less efficient though, so the temporary functions from the previous section are better off with `@memoize`.
+
+## Documentation
+
+Methods are documented with reStructuredText inside docstrings. This looks a little like markdown, but it's different, so take care and look at other docstrings for examples.
+
+Documentation is automatically generated and ends up at [Read the Docs](https://hypothesis.readthedocs.io/en/latest/).
+
+To build the documentation locally, run `make html` inside the `docs/` directory. This generates a manual in `docs/_build/html/`.
+
+New modules have to be added to `docs/nnf.rst` to be documented.
+
+## Style/miscellaneous
+
+- Prefer sets over lists where it make sense. For example, `Or({~c for c in children} | {aux})` instead of `Or([~c for c in children] + [aux])`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ tox
 
 This will install and run all the tooling.
 
+`tox` aborts early if one of the steps fails. To run just the tests (for example if you can't get `mypy` to work), install and run [`pytest`](https://docs.pytest.org/en/latest/getting-started.html). To run just one particular test, run `pytest -k <name of test>`.
+
 ## Mypy
 
 [Mypy](https://mypy.readthedocs.io/en/stable/) is used for static typing. This is also managed by `tox`.

--- a/docs/caveats.rst
+++ b/docs/caveats.rst
@@ -44,11 +44,11 @@ Decomposability and determinism
 
 A lot of methods are much faster to perform on sentences that are decomposable or deterministic, such as model enumeration.
 
-Decomposability is automatically detected. However, you can skip the check if you already know whether the sentence is decomposable or not, by passing ``decomposable=True`` or ``decomposable=False`` as a keyword argument.
+Decomposability is automatically detected.
 
-Determinism is too expensive to automatically detect, but it can give a huge speedup. If you know a sentence to be deterministic, pass ``deterministic=True`` as a keyword argument to take advantage.
+Determinism is too expensive to automatically detect, but it can give a huge speedup. If you know a sentence to be deterministic, run ``.mark_deterministic()`` to enable the relevant optimizations.
 
-A compiler like `DSHARP <https://github.com/QuMuLab/dsharp>`_ may be able to convert some sentences into equivalent deterministic decomposable sentences. The output of DSHARP can be loaded using the :mod:`nnf.dsharp` module.
+A compiler like `DSHARP <https://github.com/QuMuLab/dsharp>`_ may be able to convert some sentences into equivalent deterministic decomposable sentences. The output of DSHARP can be loaded using the :mod:`nnf.dsharp` module. Sentences returned by :func:`nnf.dsharp.compile` are automatically marked as deterministic.
 
 Other duplication inefficiencies
 --------------------------------

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+# -*- conf -*-
+[mypy]
+strict = True

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -318,9 +318,8 @@ class NNF(metaclass=abc.ABCMeta):
 
         if self.is_CNF():
             return self._cnf_satisfiable()
-        else:
-            from nnf import tseitin
-            return tseitin.to_CNF(self)._cnf_satisfiable()
+
+        return self.to_CNF()._cnf_satisfiable()
 
     def _satisfiable_decomposable(self) -> bool:
         """Checks satisfiability of decomposable sentences.

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -726,9 +726,9 @@ class NNF(metaclass=abc.ABCMeta):
             And(Var(name, val) for name, val in model.items())
             for model in self.models()
         )
-        NNF.is_MODS.memo[new] = True
-        NNF._is_DNF_loose.memo[new] = True
-        NNF._is_DNF_strict.memo[new] = True
+        NNF.is_MODS.set(new, True)
+        NNF._is_DNF_loose.set(new, True)
+        NNF._is_DNF_strict.set(new, True)
         return new
 
     def to_model(self) -> Model:
@@ -810,7 +810,7 @@ class NNF(metaclass=abc.ABCMeta):
             return new
 
         ret = smooth(self)
-        NNF.smooth.memo[ret] = True
+        NNF.smooth.set(ret, True)
         return ret
 
     def simplify(self, merge_nodes: bool = True) -> 'NNF':

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -472,7 +472,7 @@ class NNF(metaclass=abc.ABCMeta):
 
             return count(sentence)
 
-        return len(list(sentence.models()))
+        return sum(1 for _ in sentence.models())
 
     def contradicts(
             self,

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -807,7 +807,7 @@ class NNF(metaclass=abc.ABCMeta):
         the sentence that are strict subsets of any of the clauses in this
         representation, so no clauses could be made smaller.
 
-        While :meth:`NNF.implicants` returns all implicants, this method may
+        While :meth:`implicants` returns all implicants, this method may
         only return some of the implicates.
         """
         return And(self._do_PI()[1])
@@ -1042,7 +1042,7 @@ class NNF(metaclass=abc.ABCMeta):
         duplication.
 
         It's better to avoid the duplication in the first place. This method is
-        for diagnostic purposes, in combination with :meth:`NNF.object_count`.
+        for diagnostic purposes, in combination with :meth:`object_count`.
         """
         new_nodes = {}  # type: t.Dict[NNF, NNF]
 

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -388,7 +388,11 @@ class NNF(metaclass=abc.ABCMeta):
             return not self.condition(other.negate().to_model()).satisfiable()
         if self.term():
             return not other.negate().condition(self.to_model()).satisfiable()
-        return (self.negate() | other).valid()  # todo: speed this up
+
+        if not self.vars() & other.vars():
+            return not self.satisfiable() or other.valid()
+
+        return not (self & other.negate()).satisfiable()
 
     entails = implies
 
@@ -458,36 +462,12 @@ class NNF(metaclass=abc.ABCMeta):
 
         return sum(1 for _ in sentence.models())
 
-    def contradicts(
-            self,
-            other: 'NNF',
-            *,
-            decomposable: _Tristate = None
-    ) -> bool:
-        """There is no set of values that satisfies both sentences.
+    def contradicts(self, other: "NNF") -> bool:
+        """There is no set of values that satisfies both sentences."""
+        if not self.vars() & other.vars():
+            return not (self.satisfiable() and other.satisfiable())
 
-        May be very expensive.
-        """
-        if decomposable is None:
-            decomposable = self.decomposable() and other.decomposable()
-
-        if len(self.vars()) > len(other.vars()):
-            # The one with the fewest vars has the smallest models
-            a, b = other, self
-        else:
-            a, b = self, other
-
-        if decomposable:
-            for model in a.models(decomposable=True):
-                if b._consistent_with_model(model):
-                    return False
-            return True
-
-        for model in b.models():
-            # Hopefully, a.vars() <= b.vars() and .satisfiable() is fast
-            if a.condition(model).satisfiable():
-                return False
-        return True
+        return not (self & other).satisfiable()
 
     def equivalent(self, other: 'NNF') -> bool:
         """Test whether two sentences have the same models.
@@ -495,85 +475,13 @@ class NNF(metaclass=abc.ABCMeta):
         If the sentences don't contain the same variables they are
         considered equivalent if the variables that aren't shared are
         independent, i.e. their value doesn't affect the value of the sentence.
-
-        Warning: may be very slow. Decomposability helps.
         """
-        # TODO: add arguments for decomposability, determinism (per sentence?)
         if self == other:
             return True
 
-        models_a = list(self.models())
-        models_b = list(other.models())
-        if models_a == models_b:
-            return True
-
-        vars_a = self.vars()
-        vars_b = other.vars()
-        if vars_a == vars_b:
-            if len(models_a) != len(models_b):
-                return False
-
-        Model_T = t.FrozenSet[t.Tuple[Name, bool]]
-
-        def dict_hashable(model: t.Dict[Name, bool]) -> Model_T:
-            return frozenset(model.items())
-
-        modset_a = frozenset(map(dict_hashable, models_a))
-        modset_b = frozenset(map(dict_hashable, models_b))
-
-        if vars_a == vars_b:
-            return modset_a == modset_b
-
-        # There are variables that appear in one sentence but not the other
-        # The sentences can still be equivalent if those variables don't
-        # affect the truth value of the sentence they appear in
-        # That is, for every model that contains such a variable there's
-        # another model with that variable flipped
-
-        # In such a scenario we can calculate the number of "shared" models in
-        # advance
-        # Each additional variable not shared with the other doubles the
-        # number of models compared to the number of shared models
-        # so we calculate those factors and check whether that works out,
-        # which is much cheaper than actually checking everything, which we
-        # do afterwards if necessary
-        if len(modset_a) % 2**(len(vars_a - vars_b)) != 0:
-            return False
-        if len(modset_b) % 2**(len(vars_b - vars_a)) != 0:
-            return False
-        if (len(modset_a) // 2**(len(vars_a - vars_b)) !=
-                len(modset_b) // 2**(len(vars_b - vars_a))):
-            return False
-
-        def flip(model: Model_T, var: Name) -> Model_T:
-            other = (var, False) if (var, True) in model else (var, True)
-            return (model - {(var, False), (var, True)}) | {other}
-
-        modset_a_small = set()  # type: t.Set[Model_T]
-        for model in modset_a:
-            for var in vars_a - vars_b:
-                if flip(model, var) not in modset_a:
-                    return False
-            true_vars = {(var, True) for var in vars_a - vars_b}
-            if true_vars <= model:  # Don't add it multiple times
-                modset_a_small.add(model - true_vars)
-
-        modset_b_small = set()  # type: t.Set[Model_T]
-        for model in modset_b:
-            for var in vars_b - vars_a:
-                if flip(model, var) not in modset_b:
-                    return False
-            true_vars = {(var, True) for var in vars_b - vars_a}
-            if true_vars <= model:
-                modset_b_small.add(model - true_vars)
-
-        if modset_a_small != modset_b_small:
-            return False
-
-        assert (len(modset_a_small)
-                == len(modset_a) // 2**(len(vars_a - vars_b)))
-
-        return True
+        return not (
+            (self & other.negate()) | (self.negate() & other)
+        ).satisfiable()
 
     def negate(self) -> 'NNF':
         """Return a new sentence that's true iff the original is false."""

--- a/nnf/__init__.py
+++ b/nnf/__init__.py
@@ -24,11 +24,20 @@ import uuid
 
 from collections import Counter
 
+from nnf.util import (
+    memoize,
+    T_NNF,
+    U_NNF,
+    T_NNF_co,
+    _Tristate,
+    Bottom,
+    Name,
+    Model,
+)
+
 if t.TYPE_CHECKING:
     import nnf
 
-Name = t.Hashable
-Model = t.Dict[Name, bool]
 
 __all__ = ('NNF', 'Internal', 'And', 'Or', 'Var', 'Aux', 'Builder',
            'all_models', 'complete_models', 'decision', 'true', 'false',
@@ -55,12 +64,6 @@ def all_models(names: 't.Iterable[Name]') -> t.Iterator[Model]:
             yield new
 
 
-T = t.TypeVar('T')
-T_NNF = t.TypeVar('T_NNF', bound='NNF')
-U_NNF = t.TypeVar('U_NNF', bound='NNF')
-T_NNF_co = t.TypeVar('T_NNF_co', bound='NNF', covariant=True)
-_Tristate = t.Optional[bool]
-
 # Valid values: native and kissat
 SAT_BACKEND = 'native'
 
@@ -79,13 +82,6 @@ class using_kissat():
     def __exit__(self, *_: t.Any) -> None:
         global SAT_BACKEND
         SAT_BACKEND = self.setting
-
-
-if t.TYPE_CHECKING:
-    def memoize(func: T) -> T:
-        ...
-else:
-    memoize = functools.lru_cache(maxsize=None)
 
 
 class NNF(metaclass=abc.ABCMeta):
@@ -1677,9 +1673,9 @@ def decision(
 
 
 #: A node that's always true. Technically an And node without children.
-true = And()  # type: And[NNF]
+true = And()  # type: And[Bottom]
 #: A node that's always false. Technically an Or node without children.
-false = Or()  # type: Or[NNF]
+false = Or()  # type: Or[Bottom]
 
 
 class Builder:

--- a/nnf/amc.py
+++ b/nnf/amc.py
@@ -6,7 +6,8 @@ import operator
 
 import typing as t
 
-from nnf import NNF, And, Var, Or, Internal, Name, true, false, memoize
+from nnf import NNF, And, Var, Or, Internal, true, false
+from nnf.util import Name, memoize
 
 neg_inf = float('-inf')
 

--- a/nnf/cli.py
+++ b/nnf/cli.py
@@ -154,10 +154,9 @@ def sentence_stats(verbose: bool, sentence: NNF) -> SimpleNamespace:
 def sat(args: argparse.Namespace) -> int:
     with open_read(args.file) as f:
         sentence = dimacs.load(f)
-    stats = sentence_stats(args.verbose, sentence)
+    sentence_stats(args.verbose, sentence)
     with timer(args):
-        sat = sentence.satisfiable(decomposable=stats.decomposable,
-                                   cnf=stats.cnf)
+        sat = sentence.satisfiable()
     if sat:
         if not args.quiet:
             print("SATISFIABLE")
@@ -171,11 +170,11 @@ def sat(args: argparse.Namespace) -> int:
 def sharpsat(args: argparse.Namespace) -> int:
     with open_read(args.file) as f:
         sentence = dimacs.load(f)
-    stats = sentence_stats(args.verbose, sentence)
+    if args.deterministic:
+        sentence.mark_deterministic()
+    sentence_stats(args.verbose, sentence)
     with timer(args):
-        num = sentence.model_count(decomposable=stats.decomposable,
-                                   deterministic=args.deterministic,
-                                   smooth=stats.smooth)
+        num = sentence.model_count()
     if args.quiet:
         print(num)
     else:

--- a/nnf/cli.py
+++ b/nnf/cli.py
@@ -20,6 +20,8 @@ from nnf import NNF, dimacs
 #       model enumeration
 #       ...
 
+DOT_FORMATS = {'ps', 'pdf', 'svg', 'fig', 'png', 'gif', 'jpg', 'jpeg'}
+
 
 @contextlib.contextmanager
 def timer(args: argparse.Namespace) -> t.Iterator[SimpleNamespace]:
@@ -190,9 +192,6 @@ def info(args: argparse.Namespace) -> int:
     return 0
 
 
-dot_formats = {'ps', 'pdf', 'svg', 'fig', 'png', 'gif', 'jpg', 'jpeg'}
-
-
 def extension(fname: str) -> t.Optional[str]:
     if '.' not in fname:
         return None
@@ -206,7 +205,7 @@ def draw(args: argparse.Namespace) -> int:
     dot = sentence.to_DOT(color=args.color, label=label)
 
     ext = extension(args.out)
-    if ext in dot_formats or args.format is not None:
+    if ext in DOT_FORMATS or args.format is not None:
         argv = ['dot', '-T' + (ext if args.format is None  # type: ignore
                                else args.format)]
         if args.out != '-':

--- a/nnf/dimacs.py
+++ b/nnf/dimacs.py
@@ -145,8 +145,6 @@ def _dump_cnf(
         if not isinstance(clause, Or):
             raise TypeError("CNF sentences must be conjunctions of "
                             "disjunctions")
-        if not len(clause.children) > 0:
-            raise TypeError("CNF sentences shouldn't have empty clauses")
         first = True
         for child in clause.children:
             if not isinstance(child, Var):
@@ -294,8 +292,7 @@ def _parse_cnf(tokens: t.Iterable[str]) -> And[Or[Var]]:
     clause = set()  # type: t.Set[Var]
     for token in tokens:
         if token == '0':
-            if clause:
-                clauses.add(Or(clause))
+            clauses.add(Or(clause))
             clause = set()
         elif token == '%':
             # Some example files end with:
@@ -303,7 +300,7 @@ def _parse_cnf(tokens: t.Iterable[str]) -> And[Or[Var]]:
             # %
             # 0
             # I don't know why.
-            pass
+            break
         elif token.startswith('-'):
             clause.add(Var(int(token[1:]), False))
         else:

--- a/nnf/dimacs.py
+++ b/nnf/dimacs.py
@@ -6,7 +6,8 @@ import io
 import typing as t
 import warnings
 
-from nnf import NNF, Var, And, Or, Name, true, false
+from nnf import NNF, Var, And, Or, true, false
+from nnf.util import Name
 
 __all__ = ('dump', 'load', 'dumps', 'loads')
 

--- a/nnf/dimacs.py
+++ b/nnf/dimacs.py
@@ -312,4 +312,6 @@ def _parse_cnf(tokens: t.Iterable[str]) -> And[Or[Var]]:
         # A file may or may not end with a 0
         # Adding an empty clause is not desirable
         clauses.add(Or(clause))
-    return And(clauses)
+    sentence = And(clauses)
+    NNF._is_CNF_loose.memo[sentence] = True
+    return sentence

--- a/nnf/dimacs.py
+++ b/nnf/dimacs.py
@@ -313,5 +313,5 @@ def _parse_cnf(tokens: t.Iterable[str]) -> And[Or[Var]]:
         # Adding an empty clause is not desirable
         clauses.add(Or(clause))
     sentence = And(clauses)
-    NNF._is_CNF_loose.memo[sentence] = True
+    NNF._is_CNF_loose.set(sentence, True)
     return sentence

--- a/nnf/dsharp.py
+++ b/nnf/dsharp.py
@@ -144,5 +144,5 @@ def compile(
 
     result = loads(out, var_labels=var_labels)
     result.mark_deterministic()
-    NNF.decomposable.memo[result] = True
+    NNF.decomposable.set(result, True)
     return result

--- a/nnf/dsharp.py
+++ b/nnf/dsharp.py
@@ -81,6 +81,8 @@ def compile(
 
     This requires having DSHARP installed.
 
+    The returned sentence will be marked as deterministic.
+
     :param sentence: The CNF sentence to compile.
     :param executable: The path of the ``dsharp`` executable. If the
                        executable is in your PATH there's no need to set this.
@@ -140,4 +142,7 @@ def compile(
     if not out:
         raise RuntimeError("Couldn't read file output. Log:\n\n{}".format(log))
 
-    return loads(out, var_labels=var_labels)
+    result = loads(out, var_labels=var_labels)
+    result.mark_deterministic()
+    NNF.decomposable.memo[result] = True
+    return result

--- a/nnf/dsharp.py
+++ b/nnf/dsharp.py
@@ -25,7 +25,7 @@ import subprocess
 import tempfile
 import typing as t
 
-from nnf import NNF, And, Or, Var, false, dimacs
+from nnf import NNF, And, Or, Var, false, true, dimacs
 from nnf.util import Name
 
 __all__ = ('load', 'loads', 'compile')
@@ -99,6 +99,12 @@ def compile(
 
     if not sentence.is_CNF():
         raise ValueError("Sentence must be in CNF")
+
+    # Handle cases D# doesn't like
+    if not sentence.children:
+        return true
+    if false in sentence.children:
+        return false
 
     var_labels = dict(enumerate(sentence.vars(), start=1))
     var_labels_inverse = {v: k for k, v in var_labels.items()}

--- a/nnf/dsharp.py
+++ b/nnf/dsharp.py
@@ -25,7 +25,8 @@ import subprocess
 import tempfile
 import typing as t
 
-from nnf import NNF, And, Or, Var, false, dimacs, Name
+from nnf import NNF, And, Or, Var, false, dimacs
+from nnf.util import Name
 
 __all__ = ('load', 'loads', 'compile')
 

--- a/nnf/kissat.py
+++ b/nnf/kissat.py
@@ -8,7 +8,8 @@ import shutil
 import subprocess
 import typing as t
 
-from nnf import And, Or, Var, dimacs, Model
+from nnf import And, Or, Var, dimacs
+from nnf.util import Model
 
 __all__ = ('solve',)
 

--- a/nnf/operators.py
+++ b/nnf/operators.py
@@ -7,7 +7,8 @@ inefficient.
 
 import typing as t
 
-from nnf import NNF, And, Or, T_NNF, U_NNF
+from nnf import NNF, And, Or
+from nnf.util import T_NNF, U_NNF
 
 __all__ = ('xor', 'nand', 'nor', 'implies', 'implied_by', 'iff', 'and_', 'or_')
 

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -6,7 +6,8 @@ polynomial time/space. It does so at the cost of introducing new variables
 (one for each logical connective in the formula).
 """
 
-from nnf import NNF, Var, And, Or, memoize, Internal
+from nnf import NNF, Var, And, Or, Internal
+from nnf.util import memoize
 
 
 def to_CNF(theory: NNF) -> And[Or[Var]]:

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -53,6 +53,6 @@ def to_CNF(theory: NNF) -> And[Or[Var]]:
     root = process_node(theory)
     clauses.append(Or({root}))
     ret = And(clauses)
-    NNF._is_CNF_loose.memo[ret] = True
-    NNF._is_CNF_strict.memo[ret] = True
+    NNF._is_CNF_loose.set(ret, True)
+    NNF._is_CNF_strict.set(ret, True)
     return ret

--- a/nnf/tseitin.py
+++ b/nnf/tseitin.py
@@ -52,4 +52,7 @@ def to_CNF(theory: NNF) -> And[Or[Var]]:
 
     root = process_node(theory)
     clauses.append(Or({root}))
-    return And(clauses)
+    ret = And(clauses)
+    NNF._is_CNF_loose.memo[ret] = True
+    NNF._is_CNF_strict.memo[ret] = True
+    return ret

--- a/nnf/util.py
+++ b/nnf/util.py
@@ -1,0 +1,28 @@
+"""Utility definitions for internal use. Not part of the public API."""
+
+import functools
+import typing as t
+
+if t.TYPE_CHECKING:
+    from nnf import NNF  # noqa: F401
+
+Name = t.Hashable
+Model = t.Dict[Name, bool]
+
+T = t.TypeVar("T")
+U = t.TypeVar("U")
+T_NNF = t.TypeVar("T_NNF", bound="NNF")
+U_NNF = t.TypeVar("U_NNF", bound="NNF")
+T_NNF_co = t.TypeVar("T_NNF_co", bound="NNF", covariant=True)
+_Tristate = t.Optional[bool]
+
+# Bottom type with no values
+# This works in mypy but not pytype
+# t.Union[()] works too but not at runtime
+# NoReturn doesn't exist in some Python releases, hence the guard
+if t.TYPE_CHECKING:
+    Bottom = t.NoReturn
+else:
+    Bottom = None
+
+memoize = t.cast(t.Callable[[T], T], functools.lru_cache(maxsize=None))

--- a/nnf/util.py
+++ b/nnf/util.py
@@ -2,6 +2,7 @@
 
 import functools
 import typing as t
+import weakref
 
 if t.TYPE_CHECKING:
     from nnf import NNF  # noqa: F401
@@ -26,3 +27,79 @@ else:
     Bottom = None
 
 memoize = t.cast(t.Callable[[T], T], functools.lru_cache(maxsize=None))
+
+
+class _WeakrefMemoized(t.Generic[T_NNF, T]):
+    def __init__(self) -> None:
+        assert t.TYPE_CHECKING, "Not a real class"
+        self.memo = NotImplemented  # type: weakref.WeakKeyDictionary[T_NNF, T]
+        self.__wrapped__ = NotImplemented  # type: t.Callable[[T_NNF], T]
+
+    @t.overload
+    def __get__(self: U, instance: None, owner: t.Type[T_NNF]) -> "U":
+        ...
+
+    @t.overload  # noqa: F811
+    def __get__(  # noqa: F811
+        self, instance: T_NNF, owner: t.Optional[t.Type[T_NNF]] = None
+    ) -> t.Callable[[], T]:
+        ...
+
+    def __get__(  # noqa: F811
+        self, instance: object, owner: object = None
+    ) -> t.Any:
+        ...
+
+    def __call__(self, sentence: T_NNF) -> T:
+        ...
+
+
+def weakref_memoize(
+    func: t.Callable[[T_NNF], T]
+) -> _WeakrefMemoized[T_NNF, T]:
+    """Make a function cache its return values using weakrefs.
+
+    This makes it possible to remember sentences' properties without keeping
+    them in memory forever.
+
+    To keep memory use reasonable, this decorator should only be used on
+    methods that will only be called on full sentences, not individual nodes
+    within a sentence.
+
+    The current implementation has a problem: WeakKeyDictionary operates on
+    object equality, not identity. Consider the following:
+
+        >>> d = weakref.WeakKeyDictionary()
+        >>> s = nnf.And()
+        >>> t = nnf.And()
+        >>> d[s] = 3
+        >>> t in d
+        True
+        >>> del s
+        >>> t in d
+        False
+
+    When ``s`` is garbage collected, ``t`` can no longer be looked up in the
+    dictionary, even though we did look it up before.
+
+    This might be acceptable because the methods this wraps around aren't
+    prohibitively expensive.
+
+    For a solution that can't easily be applied here, see the implementation of
+    :meth:`nnf.NNF.mark_deterministic`.
+    """
+    memo = (
+        weakref.WeakKeyDictionary()
+    )  # type: weakref.WeakKeyDictionary[T_NNF, T]
+
+    @functools.wraps(func)
+    def wrapped(self: T_NNF) -> T:
+        try:
+            return memo[self]
+        except KeyError:
+            ret = func(self)
+            memo[self] = ret
+            return ret
+
+    wrapped.memo = memo  # type: ignore
+    return t.cast(_WeakrefMemoized[T_NNF, T], wrapped)

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -639,13 +639,11 @@ def test_implicants(sentence: nnf.NNF):
 
 
 @given(NNF())
-def test_implicates_implicants_idempotent(sentence: nnf.NNF):
+def test_implicants_idempotent(sentence: nnf.NNF):
     assume(len(sentence.vars()) <= 6)
     implicants = sentence.implicants()
     implicates = sentence.implicates()
     assert implicants.implicants() == implicants
-    assert implicates.implicates() == implicates
-    assert implicants.implicates() == implicates
     assert implicates.implicants() == implicants
 
 

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -321,7 +321,9 @@ def test_arbitrary_dimacs_sat_serialize(sentence: nnf.NNF):
 @given(CNF())
 def test_arbitrary_dimacs_cnf_serialize(sentence: nnf.And):
     assume(all(len(clause.children) > 0 for clause in sentence.children))
-    assert dimacs.loads(dimacs.dumps(sentence, mode='cnf')) == sentence
+    reloaded = dimacs.loads(dimacs.dumps(sentence, mode='cnf'))
+    assert reloaded.is_CNF()
+    assert reloaded == sentence
 
 
 @given(NNF())
@@ -601,6 +603,9 @@ def test_to_MODS(sentence: nnf.NNF):
     assume(len(sentence.vars()) <= 5)
     mods = sentence.to_MODS()
     assert mods.is_MODS()
+    assert mods.is_DNF()
+    assert mods.is_DNF(strict=True)
+    assert mods.smooth()
     assert isinstance(mods, Or)
     assert mods.model_count() == len(mods.children)
 
@@ -874,6 +879,7 @@ def test_tseitin(sentence: nnf.NNF):
 
     T = tseitin.to_CNF(sentence)
     assert T.is_CNF()
+    assert T.is_CNF(strict=True)
     assert T.forget_aux().equivalent(sentence)
 
     models = list(complete_models(T.models(), sentence.vars() | T.vars()))

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -666,6 +666,7 @@ def test_implicates_implicants_negation_rule(sentence: nnf.NNF):
     So sentence.negate().implicants().negate() gives all implicates,
     and sentence.negate().implicates().negate() gives some implicants.
     """
+    assume(sentence.size() <= 30)
     assert (
         sentence.negate().implicants().negate().children
         >= sentence.implicates().children

--- a/test_nnf.py
+++ b/test_nnf.py
@@ -828,6 +828,7 @@ def test_tseitin(sentence: nnf.NNF):
 
     assert len(models) == sentence.model_count()
 
+
 @given(models())
 def test_complete_models(model: nnf.And[nnf.Var]):
     m = {v.name: v.true for v in model}
@@ -844,10 +845,13 @@ def test_complete_models(model: nnf.And[nnf.Var]):
     assert all(x.keys() == m.keys() | {"test1", "test2"} for x in two)
 
     if m:
-        multi = list(complete_models([m, neg], model.vars() | {"test1", "test2"}))
+        multi = list(
+            complete_models([m, neg], model.vars() | {"test1", "test2"})
+        )
         assert len(multi) == 8
         assert len({frozenset(x.items()) for x in multi}) == 8  # all unique
         assert all(x.keys() == m.keys() | {"test1", "test2"} for x in multi)
+
 
 if (platform.uname().system, platform.uname().machine) == ('Linux', 'x86_64'):
 
@@ -865,4 +869,7 @@ if (platform.uname().system, platform.uname().machine) == ('Linux', 'x86_64'):
     @given(NNF())
     def test_kissat_nnf(sentence: And[Or[Var]]):
         with using_kissat():
-            assert sentence.satisfiable() == tseitin.to_CNF(sentence)._cnf_satisfiable_native()
+            assert (
+                sentence.satisfiable()
+                == tseitin.to_CNF(sentence)._cnf_satisfiable_native()
+            )

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = py34, py35, py36, py37, py38, pypy3
+envlist = py3
 toxworkdir = {env:TOX_WORK_DIR:.tox}
 
 [testenv]
 deps =
     pytest
     flake8
-    py{3,35,36,37,38}: mypy
+    py{3,35,36,37,38,39}: mypy
     hypothesis
 commands =
     flake8 nnf test_nnf.py
-    py{3,35,36,37,38}: python -m mypy --strict nnf
+    py{3,35,36,37,38,39}: mypy nnf
+    py{3,35,36,37,38,39}: mypy --python-version=3.4 nnf
     pytest
-    py{3,36,37,38,py3}: python -m doctest nnf/__init__.py -o ELLIPSIS
+    py{3,36,37,38,39,py3}: python -m doctest nnf/__init__.py -o ELLIPSIS
     python examples/socialchoice.py

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     py{3,35,36,37,38}: mypy
     hypothesis
 commands =
-    flake8 nnf
+    flake8 nnf test_nnf.py
     py{3,35,36,37,38}: python -m mypy --strict nnf
     pytest
     py{3,36,37,38,py3}: python -m doctest nnf/__init__.py -o ELLIPSIS


### PR DESCRIPTION
- Memoize sentence properties. This makes the explicit `decomposable` and such arguments obsolete. Sentence properties are memoized using `weakref`, which limits the amount of extra memory we need per node (compared to an attribute for each property).
  A `.mark_deterministic()` method can be used to declare that a sentence is deterministic.
  Sentence properties are marked in advance when possible. This does screw with the tests a little, you have to make sure to bypass the memoization when appropriate.
- Memoize `.vars()` in the same way (resolves #12), and replace a lot of the internal use of `.vars()` by a smarter system with a temporary cache. This hugely speeds up those methods (including `.decomposable()`) on large sentences, because `.vars()` does redundant work if you run it on many nodes in the sentence. I think it takes the complexity down from quadratic to something more manageable.
  The memoization does mean that running `.vars()` on individual nodes is inadvisable, because it associates a whole new `frozenset` with each. It's something you should try to only run on full sentences. That goes for memoized methods in general.
- Change the `is_CNF()` and `is_DNF()` semantics (resolves #14).
- Change a few methods to very simple implementations that use `.satisfiable()`, now that it uses a SAT solver as a sane baseline. This slows them down for some cases and speeds them up for others, but I think it massively improves the worst-case performance for each.
- A bunch of smaller fixes and changes.

@haz Can you check if you see anything that's questionable or badly explained or needs to make better use of these changes?